### PR TITLE
Classwork-7 3/6/24 

### DIFF
--- a/DroppingIndex.js
+++ b/DroppingIndex.js
@@ -1,0 +1,16 @@
+db.student.dropIndex({key: {student_id:551}},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+/* Output:
+{
+  ok: 0,
+  errmsg: "can't find index with key: { key: { student_id: 551 } }",
+  code: 27,
+  codeName: 'IndexNotFound'
+}
+*/

--- a/GeospatialIndexes.js
+++ b/GeospatialIndexes.js
@@ -1,0 +1,25 @@
+db.student.createIndex({"score":"2dsphere"},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< score_2dsphere
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student: 1 }, name: 'student_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  }
+]
+  */

--- a/MultiKeyIndex.js
+++ b/MultiKeyIndex.js
@@ -1,0 +1,19 @@
+db.student.createIndex({student:1},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_1
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student: 1 }, name: 'student_1' }
+]
+  */

--- a/compoundIndex.js
+++ b/compoundIndex.js
@@ -1,0 +1,18 @@
+db.student.createIndex({student_id: 777777, student_id: 223344},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_id_223344
+> db.student.getIndexes()
+
+/* Output:
+  [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' }
+]
+  */

--- a/singleFieldindex.js
+++ b/singleFieldindex.js
@@ -1,0 +1,19 @@
+db.student.createIndex({"class_id":551},
+{
+"createdCollectionAutomatically" :
+false,
+"numIndexesBefore": 1,
+"numIndexsAfter": 2,
+"ok" : 1
+})
+
+< class_id_551
+> db.student.getIndexes()
+
+/*
+Output:
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { class_id: 551 }, name: 'class_id_551' }
+]
+*/


### PR DESCRIPTION
In MongoDB, indexes are special data structures that significantly improve the performance of queries. They act like an organized filing system for your data, allowing MongoDB to quickly locate specific documents. Indexes work like a card catalog in a library. Each index focuses on a specific field (like book title or author) and keeps track of where documents with those values are stored. When you search for a document using an indexed field, MongoDB can quickly locate the relevant documents without scanning the entire collection. Here are the basic steps to create and use indexes in MongoDB.
1)Single Field Index: A single field index in MongoDB is an index that is created on a single field within a document in a MongoDB collection.
![image](https://github.com/edaraa2/Adv-Database-Design/assets/156957884/79932b2f-3a7a-4227-bdc9-93d77a719b92)
2)Compound Index:
This index involves multiple fields within a document, optimizing query performance when multiple criteria are used or when sorting and filtering need to be conducted on several fields simultaneously.
![image](https://github.com/edaraa2/Adv-Database-Design/assets/156957884/f43e1722-e086-42f3-be9a-f184c52bd916)
)Multi-Key Index:
Multi-key index is a special type of index in MongoDB that goes beyond indexing a single field. It allows MongoDB to efficiently search for documents based on combinations of multiple fields. While multi-key indexes improve read performance, they can increase write overhead as the index needs to be updated for insertions and modifications involving the indexed fields.
. Imagine it like a two-dimensional filing system instead of a single shelf
![image](https://github.com/edaraa2/Adv-Database-Design/assets/156957884/4f8acfae-c3d2-457e-99e6-65428d22e857)

4)Geospatial Indexes:
•  A traditional index wouldn't be very helpful for finding nearby restaurants. Geospatial indexes act like a special map index, enabling MongoDB to efficiently locate POIs within a specific area or based on proximity to a given point.
•  GeoJSON Support: MongoDB supports GeoJSON, a standardized format for encoding geographical data like points, lines, and polygons. Geospatial indexes can be created on GeoJSON fields within your documents. 
•  Types of Geospatial Indexes: MongoDB offers two main types of geospatial indexes: 
•	2dsphere Index: This is ideal for spherical queries, representing locations on the Earth's surface. It supports queries like finding restaurants within a specific radius or along a route.
•	2d Index: This is suited for flat surface queries, useful for non-spherical geographical data or situations where precise spherical calculations aren't critical
![image](https://github.com/edaraa2/Adv-Database-Design/assets/156957884/357540af-d5d8-487a-8768-d18767592e88)

5) Dropping an Index: Dropping an index in MongoDB is a straightforward process. You can use the dropIndex() method to remove an existing index from a collection.
Here's the basic syntax:
db.collection.dropIndex("index_name")
![image](https://github.com/edaraa2/Adv-Database-Design/assets/156957884/1eef9f63-1789-4c84-bbac-5a6f44577f38)
